### PR TITLE
fix(business_central): Remove useless triggers

### DIFF
--- a/InitialSetup.al
+++ b/InitialSetup.al
@@ -352,8 +352,6 @@ codeunit 90101 FivetranGlobalEventHandle
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Global Triggers", 'GetDatabaseTableTriggerSetup', '', true, true)]
     local procedure GetDatabaseTableTriggerSetup(TableId: Integer; var OnDatabaseInsert: Boolean; var OnDatabaseModify: Boolean; var OnDatabaseDelete: Boolean)
     begin
-        OnDatabaseInsert := false;
-        OnDatabaseModify := false;
         OnDatabaseDelete := true;
     end;
 


### PR DESCRIPTION
Verified by:

- Generating extension via VS Code
- Installing extension in MBC
- Made changes in MBC (inserted, updated, deleted) records in MBC.
- All reflected in the Fivetran destination after sync.